### PR TITLE
Feat: Add config option to toggle loaded message visibility

### DIFF
--- a/src/main/java/io/github/linkfgfgui/emi_patternizer/Config.java
+++ b/src/main/java/io/github/linkfgfgui/emi_patternizer/Config.java
@@ -10,6 +10,7 @@ public class Config {
     public static final ModConfigSpec.LongValue DELAY_BEFORE_READ = BUILDER.comment("Delay before read patterns from terminal (Unit: Millisecond)").translation("emi_patternizer.config.delay3").defineInRange("delayBeforeRead", 1000, 0, Long.MAX_VALUE);
     public static final ModConfigSpec.BooleanValue IS_PLAY_SOUND = BUILDER.comment("Play a sound after recipe fill").translation("emi_patternizer.config.playsound").define("isPlaySound", true);
     public static final ModConfigSpec.BooleanValue IS_SIMULATE_CLICK = BUILDER.comment("Whether to simulate a encode button click").translation("emi_patternizer.config.simulate").define("isSimulateClick", false);
+    public static final ModConfigSpec.BooleanValue IS_SHOW_LOAD_MESSAGE = BUILDER.comment("Whether to show the loaded message").translation("emi_patternizer.config.loaded").define("isShowLoaded", true);
 
     static final ModConfigSpec SPEC = BUILDER.build();
 }

--- a/src/main/java/io/github/linkfgfgui/emi_patternizer/ReloadMemory.java
+++ b/src/main/java/io/github/linkfgfgui/emi_patternizer/ReloadMemory.java
@@ -29,7 +29,9 @@ public class ReloadMemory {
                 minecraft.execute(() -> {
                     PatternCount = api.getPatternCount(level);
                     if (minecraft.player != null) {
-                        minecraft.player.sendSystemMessage(Component.translatable("chat.emi_patternizer.loaded", EncodedItems.size(), PatternCount));
+                        if (Config.IS_SHOW_LOAD_MESSAGE.getAsBoolean()) {
+                            minecraft.player.sendSystemMessage(Component.translatable("chat.emi_patternizer.loaded", EncodedItems.size(), PatternCount));
+                        }
                     }
                 });
             });

--- a/src/main/resources/assets/emi_patternizer/lang/en_us.json
+++ b/src/main/resources/assets/emi_patternizer/lang/en_us.json
@@ -7,5 +7,6 @@
   "emi_patternizer.config.delay2": "Additional delay after 3 clicks",
   "emi_patternizer.config.delay3": "Delay before read patterns from terminal (Unit: Millisecond)",
   "emi_patternizer.config.playsound": "Play a sound after recipe fill",
-  "emi_patternizer.config.simulate": "Whether to simulate a encode button click"
+  "emi_patternizer.config.simulate": "Whether to simulate a encode button click",
+  "emi_patternizer.config.loaded": "Whether to show the loaded message"
 }

--- a/src/main/resources/assets/emi_patternizer/lang/zh_cn.json
+++ b/src/main/resources/assets/emi_patternizer/lang/zh_cn.json
@@ -7,5 +7,6 @@
   "emi_patternizer.config.delay2": "每个样板编码完成后的额外延迟",
   "emi_patternizer.config.delay3": "读取样板前的延迟（单位：毫秒）",
   "emi_patternizer.config.playsound": "转移配方后播放音效",
-  "emi_patternizer.config.simulate": "模拟点击编码按钮"
+  "emi_patternizer.config.simulate": "模拟点击编码按钮",
+  "emi_patternizer.config.loaded": "显示样板库重加载提示"
 }


### PR DESCRIPTION
- Introduce a new configuration option `IS_SHOW_LOAD_MESSAGE` to control whether the pattern library reload message is displayed.
- Conditionally display the pattern library reload message based on the new configuration setting.
- Add localization entries for the new configuration option.